### PR TITLE
Fix rangeValCopy-ref

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,9 +92,9 @@ func initVar() error {
 			return err
 		}
 
-		for _, r := range routes {
-			if r.Gw != nil {
-				gateway = r.Gw.String()
+		for i := range routes {
+			if routes[i].Gw != nil {
+				gateway = routes[i].Gw.String()
 				break
 			}
 		}


### PR DESCRIPTION
Found using gocritic
main.go:95:3: rangeValCopy: each iteration copies 152 bytes (consider pointers or indexing)